### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Building the sample application is quite simple.
 
 First configure it, then just call make to build it.
 
-        make menconfig # Create the ".config" file
+        make menuconfig # Create the ".config" file
         make           # Build the application
 
 These steps generate a small executable `myapp`,


### PR DESCRIPTION
Fix a typo in the example commands, "menconfig" was used instead of "menuconfig"